### PR TITLE
Update trie search

### DIFF
--- a/src/Larkins.AdventOfCode/Utilities/Trie.cs
+++ b/src/Larkins.AdventOfCode/Utilities/Trie.cs
@@ -1,5 +1,12 @@
 namespace Larkins.AdventOfCode.Utilities;
 
+public enum WordSearchResult
+{
+    Found,
+    StartOfWord,
+    NotFound
+}
+
 /// <summary>
 /// A Trie is a type of search tree.
 /// https://en.wikipedia.org/wiki/Trie
@@ -27,7 +34,15 @@ public class Trie
         currentNode!.IsWord = true;
     }
 
-    public bool HasWord(string word)
+    public void AddWords(IEnumerable<string> words)
+    {
+        foreach (var word in words)
+        {
+            AddWord(word);
+        }
+    }
+
+    public WordSearchResult SearchForWord(string word)
     {
         var currentNode = root;
         foreach (var @char in word)
@@ -36,11 +51,13 @@ public class Trie
 
             if (!hasNextCharNode)
             {
-                return false;
+                return WordSearchResult.NotFound;
             }
         }
 
-        return currentNode!.IsWord;
+        return currentNode!.IsWord
+            ? WordSearchResult.Found
+            : WordSearchResult.StartOfWord;
     }
 
     private class Node

--- a/tests/Larkins.AdventOfCode.Tests/UtilityTests/TrieTests.cs
+++ b/tests/Larkins.AdventOfCode.Tests/UtilityTests/TrieTests.cs
@@ -6,72 +6,77 @@ namespace Larkins.AdventOfCode.Tests.UtilityTests;
 
 public class TrieTests
 {
+    // Words
+    private const string Word = "word";
+    private const string Treatment = "treatment";
+    private const string Treat = "treat";
+    private const string Nope = "nope";
+    private const string Meat = "meat";
+    private const string Seat = "seat";
+    
     // Performance tests
     // - only the minimum number of nodes needed are present. Can this be tested?
 
     [Fact]
     public void Trie_contains_added_word()
     {
-        const string word = "word";
+        
         var sut = new Trie();
-        sut.AddWord(word);
+        sut.AddWord(Word);
 
-        var result = sut.HasWord(word);
+        var result = sut.SearchForWord(Word);
 
-        result.Should().BeTrue();
+        result.Should().Be(WordSearchResult.Found);
     }
 
+    [Fact]
+    public void Same_word_added_separately_to_trie_makes_no_changes()
+    {
+        var sut = new Trie();
+        
+        sut.AddWord(Word);
+        sut.AddWord(Word);
+        
+        var result = sut.SearchForWord(Word);
+
+        result.Should().Be(WordSearchResult.Found);
+    }
+    
     [Fact]
     public void Same_word_added_to_trie_makes_no_changes()
     {
         var sut = new Trie();
-        const string word = "word";
         
-        sut.AddWord(word);
-        sut.AddWord(word);
+        sut.AddWords([Word, Word]);
         
-        var result = sut.HasWord(word);
+        var result = sut.SearchForWord(Word);
 
-        result.Should().BeTrue();
+        result.Should().Be(WordSearchResult.Found);
     }
-    
+
     [Fact]
     public void Trie_contains_both_added_words_when_the_second_word_is_part_of_the_first_word()
     {
-        const string treatment = "treatment";
-        const string treat = "treat";
-        
         var sut = new Trie();
-        sut.AddWord(treatment);
-        sut.AddWord(treat);
+        sut.AddWords([Treat, Treatment]);
         
-        var hasTreatment = sut.HasWord(treatment);
-        var hasTreat = sut.HasWord(treat);
-
         using (new AssertionScope())
         {
-            hasTreatment.Should().BeTrue();
-            hasTreat.Should().BeTrue();
+            sut.SearchForWord(Treatment).Should().Be(WordSearchResult.Found);
+            sut.SearchForWord(Treat).Should().Be(WordSearchResult.Found);
         }
     }
     
     [Fact]
     public void Trie_contains_both_added_words_when_the_first_word_is_part_of_the_second_word()
     {
-        const string treatment = "treatment";
-        const string treat = "treat";
-        
         var sut = new Trie();
-        sut.AddWord(treat);
-        sut.AddWord(treatment);
-        
-        var hasTreatment = sut.HasWord(treatment);
-        var hasTreat = sut.HasWord(treat);
+        sut.AddWords([Treat, Treatment]);
 
         using (new AssertionScope())
         {
-            hasTreatment.Should().BeTrue();
-            hasTreat.Should().BeTrue();
+            sut.SearchForWord(Treatment).Should().Be(WordSearchResult.Found);
+            sut.SearchForWord(Treat).Should().Be(WordSearchResult.Found);
         }
     }
 
@@ -80,19 +85,53 @@ public class TrieTests
     {
         var sut = new Trie();
        
-        var result = sut.HasWord("nope");
+        var result = sut.SearchForWord(Nope);
 
-        result.Should().BeFalse();
+        result.Should().Be(WordSearchResult.NotFound);
+    }
+    
+    /// <summary>
+    /// A searched for word not in the trie could be the start of another word.
+    /// Knowing this can be helpful if adding to the search word might find a word.
+    /// </summary>
+    [Fact]
+    public void Trie_indicates_when_search_word_is_start_of_added_word()
+    {
+        var sut = new Trie();
+        sut.AddWord(Treatment);
+        
+        var result = sut.SearchForWord(Treat);
+
+        result.Should().Be(WordSearchResult.StartOfWord);
+    }
+
+    [Fact]
+    public void Trie_contains_all_added_words()
+    {
+        var sut = new Trie();
+        sut.AddWords([Meat, Seat, Treat]);
+
+        using (new AssertionScope())
+        {
+            sut.SearchForWord(Meat).Should().Be(WordSearchResult.Found);
+            sut.SearchForWord(Treat).Should().Be(WordSearchResult.Found);
+            sut.SearchForWord(Seat).Should().Be(WordSearchResult.Found);
+        }
     }
     
     [Fact]
-    public void Trie_does_not_contain_word_that_an_added_word_starts_with()
+    public void Trie_contains_all_separately_added_words()
     {
         var sut = new Trie();
-        sut.AddWord("treatment");
-        
-        var result = sut.HasWord("treat");
+        sut.AddWord(Meat);
+        sut.AddWord(Treat);
+        sut.AddWord(Seat);
 
-        result.Should().BeFalse();
+        using (new AssertionScope())
+        {
+            sut.SearchForWord(Meat).Should().Be(WordSearchResult.Found);
+            sut.SearchForWord(Treat).Should().Be(WordSearchResult.Found);
+            sut.SearchForWord(Seat).Should().Be(WordSearchResult.Found);
+        }
     }
 }


### PR DESCRIPTION
A trie is used to search for a word. If the trie doesn't contain the word, but the searched for word is the start of an added word, then the trie's search result will convey this.