### PR TITLE
Rename 2023 Solvers

### DIFF
--- a/src/Larkins.AdventOfCode/AdventOfCode2023/Day01/Year2023Day01Part01Solver.cs
+++ b/src/Larkins.AdventOfCode/AdventOfCode2023/Day01/Year2023Day01Part01Solver.cs
@@ -1,6 +1,6 @@
 namespace Larkins.AdventOfCode.AdventOfCode2023.Day01;
 
-public class Day01Part01Solver
+public class Year2023Day01Part01Solver
 {
     public int Solve(IEnumerable<string> input) => input.Sum(ConciseCalibrationValueExtract);
 

--- a/tests/Larkins.AdventOfCode.Tests/AdventOfCode2023/Day01/Year2023Day01Part01Tests.cs
+++ b/tests/Larkins.AdventOfCode.Tests/AdventOfCode2023/Day01/Year2023Day01Part01Tests.cs
@@ -3,7 +3,7 @@ using Larkins.AdventOfCode.AdventOfCode2023.Day01;
 
 namespace Larkins.AdventOfCode.Tests.AdventOfCode2023.Day01;
 
-public class Day01Part01Tests
+public class Year2023Day01Part01Tests
 {
     [Theory]
     [InlineData("1abc2", 12)]
@@ -14,7 +14,7 @@ public class Day01Part01Tests
         string inputLine,
         int expected)
     {
-        var solver = new Day01Part01Solver();
+        var solver = new Year2023Day01Part01Solver();
         var result = solver.Solve([inputLine]);
 
         result.Should().Be(expected);
@@ -31,7 +31,7 @@ public class Day01Part01Tests
             """;
         var inputLines = input.Split(Environment.NewLine);
 
-        var solver = new Day01Part01Solver();
+        var solver = new Year2023Day01Part01Solver();
         var result = solver.Solve(inputLines);
 
         result.Should().Be(142);


### PR DESCRIPTION
This is to more easily distinguish the solvers and their tests between years.